### PR TITLE
Create Get-CLocalGroupMember

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ### Upgrade Instructions
 
-New functions are not supported on PowerShell 6, so module's minimum requirement is now PowerShell 7.
+New functions are not supported on PowerShell 6, so module's minimum requirement is now PowerShell 7. Windows PowerShell
+5.1 is still supported.
 
 If migrating from Carbon's group functions (`Add-CGroupMember`, `Get-CGroup`, `Install-CGroup`, `Remove-CGroupMember`,
 `Test-CGroup`, `Test-CGroupMember`, and `Uninstall-CGroup`):
@@ -34,6 +35,7 @@ If migrating from Carbon's group functions (`Add-CGroupMember`, `Get-CGroup`, `I
 ### Added
 
 * `Get-CLocalGroup` for getting local groups. Has support for non-wildcard lookups.
+* `Get-CLocalGroupMember` for getting local group members.
 * `Install-CLocalGroup` for installing local groups.
 * `Install-CLocalGroupMember` for adding accounts to local groups.
 * `Test-CLocalGroup` for testing if local groups exist.

--- a/Carbon.Accounts/Carbon.Accounts.psd1
+++ b/Carbon.Accounts/Carbon.Accounts.psd1
@@ -78,6 +78,7 @@
     FunctionsToExport = @(
         'ConvertTo-CSecurityIdentifier',
         'Get-CLocalGroup',
+        'Get-CLocalGroupMember',
         'Install-CLocalGroup',
         'Install-CLocalGroupMember',
         'Resolve-CIdentity',

--- a/Carbon.Accounts/Carbon.Accounts.psm1
+++ b/Carbon.Accounts/Carbon.Accounts.psm1
@@ -26,7 +26,11 @@ $script:moduleRoot = $PSScriptRoot
 $modulesroot = Join-Path -Path $script:moduleRoot -ChildPath 'Modules' -Resolve
 
 Import-Module -Name (Join-Path -Path $modulesRoot -ChildPath 'PureInvoke' -Resolve) `
-              -Function @('Invoke-AdvapiLookupAccountName', 'Invoke-AdvapiLookupAccountSid') `
+              -Function @(
+                    'Invoke-AdvapiLookupAccountName',
+                    'Invoke-AdvapiLookupAccountSid',
+                    'Invoke-NetApiNetLocalGroupGetMembers'
+                ) `
               -Verbose:$false
 
 enum Carbon_Accounts_Identity_Type

--- a/Carbon.Accounts/Functions/Get-CLocalGroupMember.ps1
+++ b/Carbon.Accounts/Functions/Get-CLocalGroupMember.ps1
@@ -1,0 +1,81 @@
+
+function Get-CLocalGroupMember
+{
+    <#
+    .SYNOPSIS
+    Gets the members of a local group.
+
+    .DESCRIPTION
+    The `Get-CLocalGroupMember` function gets the members of a local group. Pass the name of the group to the `Name`
+    parameter. All the group's members are returned as `Carbon_Accounts_Identity` objects.
+
+    If you want to get a specific group member, pass its name to the `Member` parameter. If the user isn't a member of
+    the group, the function writes an error and returns nothing. If you want to check if a principal is a member of a
+    group, use the `Test-CLocalGroupMember` function instead.
+
+    .EXAMPLE
+    Get-CLocalGroupMember -Name 'Administrators'
+
+    Demonstrates how to get the members of a local group. In this case, all the members of the Administrators group is
+    returned.
+
+    .EXAMPLE
+    Get-CLocalGroupMember -Name 'Administrators' -Member 'someuser'
+
+    Demonstrates how to get a specific member of a local group. You probably want to use `Test-CLocalGroupMember`
+    instead.
+    #>
+    [CmdletBinding(DefaultParameterSetName='ByWildcardName')]
+    param(
+        [Parameter(Mandatory, Position=0)]
+        [String] $Name,
+
+        [String] $Member
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -Session $ExecutionContext.SessionState
+
+    $group = Get-CLocalGroup -LiteralName $Name
+    if (-not $group)
+    {
+        return
+    }
+
+    $memberToFind = $null
+    if ($Member)
+    {
+        $memberToFind = Resolve-CIdentity -Name $Member
+        if (-not $memberToFind)
+        {
+            return
+        }
+    }
+
+    $foundMember = $false
+    Invoke-NetApiNetLocalGroupGetMembers -LocalGroupName $group.Name -Level 0 |
+        ForEach-Object {
+            $sid = [Security.Principal.SecurityIdentifier]::New([IntPtr]$_.SidPtr)
+            return Resolve-CIdentity -Sid $sid -ErrorAction Ignore
+        } |
+        Where-Object {
+            if ($memberToFind)
+            {
+                $isMember = $memberToFind.FullName -eq $_.FullName
+                if ($isMember)
+                {
+                    $foundMember = $true
+                }
+                return $isMember
+            }
+
+            return $true
+        } |
+        Write-Output
+
+    if ($memberToFind -and -not $foundMember)
+    {
+        $msg = "Principal ""$($memberToFind.FullName)"" is not a member of group ""$($group.Name)""."
+        Write-Error -Message $msg -ErrorAction $ErrorActionPreference
+    }
+}

--- a/Carbon.Accounts/Functions/Resolve-CIdentity.ps1
+++ b/Carbon.Accounts/Functions/Resolve-CIdentity.ps1
@@ -103,7 +103,7 @@ function Resolve-CIdentity
             Write-Error -Message "SID ""${SID}"" not found." -ErrorAction $ErrorActionPreference
             return
         }
-        return [Carbon_Accounts_Identity]::New($account.ReferencedDomainName, $account.Name, $SID, $account.Use)
+        return [Carbon_Accounts_Identity]::New($account.DomainName, $account.Name, $SID, $account.Use)
     }
 
     if ($Name.StartsWith('.\'))

--- a/Carbon.Accounts/Functions/Test-CLocalGroupMember.ps1
+++ b/Carbon.Accounts/Functions/Test-CLocalGroupMember.ps1
@@ -71,9 +71,8 @@ function Test-CLocalGroupMember
     }
 
     $existingMember =
-        Get-LocalGroupMember -Name $groupInfo.Name |
-        ForEach-Object { Resolve-CIdentityName -Name $_.Name } |
-        Where-Object { $_ -eq $principal.FullName }
+        Get-CLocalGroupMember -Name $groupInfo.Name |
+        Where-Object 'FullName' -EQ $principal.FullName
     if ($existingMember)
     {
         return $true

--- a/Carbon.Accounts/prism.lock.json
+++ b/Carbon.Accounts/prism.lock.json
@@ -2,7 +2,7 @@
   "PSModules": [
     {
       "name": "PureInvoke",
-      "version": "1.0.0-rc1",
+      "version": "1.0.0-rc10",
       "repositorySourceLocation": "https://www.powershellgallery.com/api/v2"
     }
   ]

--- a/Tests/Get-CLocalGroupMember.Tests.ps1
+++ b/Tests/Get-CLocalGroupMember.Tests.ps1
@@ -1,0 +1,44 @@
+
+#Requires -Version 5.1
+Set-StrictMode -Version 'Latest'
+
+BeforeAll {
+    Set-StrictMode -Version 'Latest'
+
+    & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Test.ps1' -Resolve)
+
+    $script:admins = Get-LocalGroupMember -Name 'Administrators'
+}
+
+Describe 'Get-CLocalGroupMember' {
+
+    BeforeEach {
+        $Global:Error.Clear()
+    }
+
+    It 'gets group members' {
+        $actualMembers = Get-CLocalGroupMember -Name 'Administrators'
+        $actualMembers | Should -HaveCount $script:admins.Count
+    }
+
+    It 'gets specific member' {
+        $expectedMember = $script:admins | Select-Object -First 1
+        $expectedMember |
+            Should -Not -BeNullOrEmpty -Because 'There must be at least one member in the Administrators group.'
+        $actualMember = Get-CLocalGroupMember -Name 'Administrators' -Member $expectedMember.Name
+        $actualMember | Should -Not -BeNullOrEmpty
+        $actualMember.FullName | Should -Be $expectedMember.Name
+    }
+
+    It 'does not find specific member' {
+        $member = Get-CLocalGroupMember -Name 'Administrators' -Member 'CarbonTestUser2' -ErrorAction SilentlyContinue
+        $member | Should -BeNullOrEmpty
+        $Global:Error | Should -Match 'is not a member'
+    }
+
+    It 'validates member' {
+        $members = Get-CLocalGroupMember -Name 'Administrators' -Member 'SnafuFubar' -ErrorAction SilentlyContinue
+        $members | Should -BeNullOrEmpty
+        $Global:Error[0] | Should -Match 'Identity.*not found'
+    }
+}

--- a/Tests/Install-CLocalGroup.Tests.ps1
+++ b/Tests/Install-CLocalGroup.Tests.ps1
@@ -39,7 +39,7 @@ BeforeAll {
 
         foreach ($member in $WithMembers)
         {
-            Get-LocalGroupMember -Name $Named -Member $member | Should -Not -BeNullOrEmpty
+            Get-CLocalGroupMember -Name $Named -Member $member | Should -Not -BeNullOrEmpty
         }
     }
 

--- a/Tests/Install-CLocalGroupMember.Tests.ps1
+++ b/Tests/Install-CLocalGroupMember.Tests.ps1
@@ -22,7 +22,7 @@ BeforeAll {
 
         foreach ($_member in $Member)
         {
-            Get-LocalGroupMember -Name $script:groupName -Member $_member | Should -Not -BeNullOrEmpty
+            Get-CLocalGroupMember -Name $script:groupName -Member $_member | Should -Not -BeNullOrEmpty
         }
     }
 
@@ -44,8 +44,8 @@ Describe 'Install-CLocalGroupMember' {
     BeforeEach {
         $Global:Error.Clear()
 
-        Get-LocalGroupMember -Name $script:groupName |
-            ForEach-Object { Remove-LocalGroupMember -Name $script:groupName -Member $_ }
+        Get-CLocalGroupMember -Name $script:groupName |
+            ForEach-Object { Remove-LocalGroupMember -Name $script:groupName -Member $_.FullName }
     }
 
     $skip = (Test-Path -Path 'env:WHS_CI') -and $env:WHS_CI -eq 'True'
@@ -103,9 +103,9 @@ Describe 'Install-CLocalGroupMember' {
 
     It 'should not add non existent member' {
         $numMembersBefore =
-            Get-LocalGroupMember -Group $script:groupName | Measure-Object | Select-Object -ExpandProperty 'Count'
+            Get-CLocalGroupMember -Name $script:groupName | Measure-Object | Select-Object -ExpandProperty 'Count'
         Install-CLocalGroupMember -Name $script:groupName -Member 'FJFDAFJ' -ErrorAction SilentlyContinue
-        Get-LocalGroupMember -Group $script:groupName | Measure-Object | Select-Object -ExpandProperty 'Count' |
+        Get-CLocalGroupMember -Name $script:groupName | Measure-Object | Select-Object -ExpandProperty 'Count' |
             Should -Be $numMembersBefore
     }
 

--- a/Tests/Uninstall-CLocalGroupMember.Tests.ps1
+++ b/Tests/Uninstall-CLocalGroupMember.Tests.ps1
@@ -47,7 +47,7 @@ BeforeAll {
         $group = Get-LocalGroup -Name $Name
         $group | Should -Not -BeNullOrEmpty
 
-        $members = Get-LocalGroupMember -Name $Name
+        $members = Get-CLocalGroupMember -Name $Name
         $members | Should -HaveCount $HasMember.Length
 
         foreach ($member in $HasMember)


### PR DESCRIPTION
Because the native Get-LocalGroupMember function fails if there is an unresolvable principal in it (i.e. a domain account that 